### PR TITLE
Merge new features into plot_forest

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@
 * `plot_build_forest()` renders a forest ggplot from any `forest_stats`
   container; most users still go through `plot_forest()`.
 * `plot_forest_theme()` is a theme factory for `plot_forest()` with keys
-  `point`, `errorbar`, `ref_line`, and `ref_band`.
+  `point`, `errorbar`, `ref_line`, `ref_band`, and `panel_color`.
 * `is_forest_stats()` predicate for the new `forest_stats` subclass.
 
 ### New datasets
@@ -58,6 +58,25 @@
   named-vector form can't express); `cov_level_ref` is then ignored with
   an informational `message()`. Existing `cov_level_ref` callers are
   unaffected.
+
+### Per-covariate coloring in forest plots
+
+* `plot_forest_theme()` gains a `panel_color` argument (a [`pmx_color()`])
+  that maps each covariate to a color. When supplied with at least one
+  named entry, `plot_forest()` colors point and errorbar layers by
+  covariate (facet) via `scale_color_manual()` and suppresses the legend,
+  since facet strips already label each covariate. Covariates absent from
+  the palette render in `grey50` and trigger a warning. Default is an
+  empty `pmx_color()` (no per-covariate coloring), preserving the prior
+  single-color behavior.
+
+### Generalized `pmx_color()`
+
+* `pmx_color()` is now variadic and accepts arbitrary named arguments,
+  mapping any discrete level to a color. Existing
+  `pmx_color(dv = ..., pred = ..., ipred = ...)` usage in `plot_gof_theme()`
+  is unchanged; the generalization enables `plot_forest_theme(panel_color = ...)`
+  per-covariate mapping.
 
 ### Dual-mode pipelines (replot without recompute)
 

--- a/R/plot_forest.R
+++ b/R/plot_forest.R
@@ -559,7 +559,8 @@ plot_build_forest <- function(
   eb_color <- if (has_panel_color) NULL else eb$color
   eb_mapping <- if (has_panel_color) {
     ggplot2::aes(
-      xmin = .data$lo, xmax = .data$hi,
+      xmin = .data$lo,
+      xmax = .data$hi,
       color = .data[[cov_name_var_str]]
     )
   } else {
@@ -608,6 +609,7 @@ plot_build_forest <- function(
     ) +
     ggplot2::coord_cartesian(clip = "off") +
     ggplot2::theme(
+      plot.title = ggplot2::element_text(face = "bold"),
       plot.margin = ggplot2::margin(
         t = 5.5,
         r = label_right_pt,
@@ -623,7 +625,7 @@ plot_build_forest <- function(
       space = "free_y",
       switch = "y"
     ) +
-    ggplot2::labs(xlab = "Value", ylab = NULL, title = metric)
+    ggplot2::labs(x = NULL, y = NULL, title = metric)
 
   if (has_panel_color) {
     palette <- unlist(pc)

--- a/R/plot_forest.R
+++ b/R/plot_forest.R
@@ -552,28 +552,47 @@ plot_build_forest <- function(
       )
   }
 
+  pc <- plottheme$panel_color
+  has_panel_color <- inherits(pc, "pmx_color") && length(pc) > 0
+
   eb <- plottheme$errorbar
+  eb_color <- if (has_panel_color) NULL else eb$color
+  eb_mapping <- if (has_panel_color) {
+    ggplot2::aes(
+      xmin = .data$lo, xmax = .data$hi,
+      color = .data[[cov_name_var_str]]
+    )
+  } else {
+    ggplot2::aes(xmin = .data$lo, xmax = .data$hi)
+  }
   base <- base +
     do.call(
       ggplot2::geom_linerange,
       compact(list(
-        mapping = ggplot2::aes(xmin = .data$lo, xmax = .data$hi),
+        mapping = eb_mapping,
         linewidth = eb$linewidth,
         linetype = eb$linetype,
         alpha = eb$alpha,
-        color = eb$color
+        color = eb_color
       ))
     )
 
   pt <- plottheme$point
+  pt_color <- if (has_panel_color) NULL else pt$color
+  pt_mapping <- if (has_panel_color) {
+    ggplot2::aes(color = .data[[cov_name_var_str]])
+  } else {
+    NULL
+  }
   base <- base +
     do.call(
       ggplot2::geom_point,
       compact(list(
+        mapping = pt_mapping,
         shape = pt$shape,
         size = pt$size,
         alpha = pt$alpha,
-        color = pt$color
+        color = pt_color
       ))
     )
 
@@ -597,7 +616,7 @@ plot_build_forest <- function(
       )
     )
 
-  base +
+  base <- base +
     ggplot2::facet_grid(
       rows = ggplot2::vars(!!rlang::sym(cov_name_var_str)),
       scales = "free_y",
@@ -605,6 +624,24 @@ plot_build_forest <- function(
       switch = "y"
     ) +
     ggplot2::labs(xlab = "Value", ylab = NULL, title = metric)
+
+  if (has_panel_color) {
+    palette <- unlist(pc)
+    cov_levels <- levels(plot_data[[cov_name_var_str]])
+    missing <- setdiff(cov_levels, names(palette))
+    if (length(missing) > 0) {
+      rlang::warn(paste0(
+        "`panel_color` is missing entries for: ",
+        paste(missing, collapse = ", "),
+        ". These covariates will render in grey50."
+      ))
+    }
+    base <- base +
+      ggplot2::scale_color_manual(values = palette, na.value = "grey50") +
+      ggplot2::guides(color = "none")
+  }
+
+  base
 }
 
 

--- a/R/pmx_element_class.R
+++ b/R/pmx_element_class.R
@@ -275,26 +275,31 @@ pmx_trend <- function(linewidth = NULL, linetype = NULL, color = NULL,
 }
 
 
-#' GOF overlay color aesthetics
+#' Discrete-level color aesthetics
 #'
-#' Creates a color element for [plot_gof_theme()] controlling the manual
-#' color scale for DV, PRED, and IPRED overlay lines.
+#' Creates a color element that maps named discrete levels to colors. Used by
+#' [plot_gof_theme()] for the DV/PRED/IPRED overlay scale and by
+#' [plot_forest_theme()] (via `panel_color`) for per-covariate facet coloring.
+#' Accepts any named arguments — each name becomes a level in the resulting
+#' manual color scale.
 #'
-#' @param dv Color for DV central tendency. Default `"blue"`.
-#' @param pred Color for PRED central tendency. Default `"red"`.
-#' @param ipred Color for IPRED central tendency. Default `"green"`.
+#' @param ... Named color arguments mapping level → color (e.g.,
+#'   `dv = "blue"`, `FOOD = "red"`). All arguments must be named.
 #'
 #' @family element constructors
 #' @return A `pmx_color` element object
 #' @export
 #' @examples
 #' pmx_color(dv = "black", pred = "purple", ipred = "darkgreen")
-pmx_color <- function(dv = NULL, pred = NULL, ipred = NULL) {
-  check_color(dv, "dv")
-  check_color(pred, "pred")
-  check_color(ipred, "ipred")
+#' pmx_color(FOOD = "firebrick", WTBL = "steelblue", Reference = "grey20")
+pmx_color <- function(...) {
+  args <- list(...)
+  if (length(args) > 0 && (is.null(names(args)) || any(!nzchar(names(args))))) {
+    rlang::abort("All arguments to `pmx_color()` must be named.")
+  }
+  for (nm in names(args)) check_color(args[[nm]], nm)
   structure(
-    compact(list(dv = dv, pred = pred, ipred = ipred)),
+    compact(args),
     class = c("pmx_color", "pmx_element")
   )
 }

--- a/R/theme_factories.R
+++ b/R/theme_factories.R
@@ -177,6 +177,13 @@ plot_doseprop_theme <- function(obs_point = NULL, linear = NULL, obs = NULL) {
 #'   `geom_linerange`; the element's `width` field is unused). See [pmx_errorbar()].
 #' @param ref_line Vertical no-effect reference line aesthetics. See [pmx_line()].
 #' @param ref_band Shaded equivalence-interval ribbon aesthetics. See [pmx_ribbon()].
+#' @param panel_color Optional per-covariate color mapping. See [pmx_color()].
+#'   When supplied with at least one named entry, point and errorbar layers
+#'   are colored by covariate (facet); the legend is suppressed since facet
+#'   strips already label each covariate. Default is an empty [pmx_color()]
+#'   (no per-covariate coloring), which keeps the single-color behavior from
+#'   `point$color` / `errorbar$color`. Covariates absent from the palette
+#'   render in grey50 and trigger a warning.
 #'
 #' @family forest plot
 #' @return A named list of theme elements
@@ -186,16 +193,22 @@ plot_doseprop_theme <- function(obs_point = NULL, linear = NULL, obs = NULL) {
 #' plot_forest_theme()
 #' plot_forest_theme(point = pmx_point(shape = 18, size = 3))
 #' plot_forest_theme(ref_band = pmx_ribbon(fill = "skyblue", alpha = 0.2))
+#' plot_forest_theme(panel_color = pmx_color(
+#'   FOOD = "firebrick", WTBL = "steelblue", Reference = "grey20"
+#' ))
 plot_forest_theme <- function(point = NULL, errorbar = NULL,
-                              ref_line = NULL, ref_band = NULL) {
+                              ref_line = NULL, ref_band = NULL,
+                              panel_color = NULL) {
   defaults <- list(
-    point    = pmx_point(shape = 16, size = 2.5, alpha = 1, color = "black"),
-    errorbar = pmx_errorbar(linewidth = 0.7, linetype = 1, alpha = 1, color = "black"),
-    ref_line = pmx_line(linewidth = 0.5, linetype = 2, alpha = 1, color = "grey40"),
-    ref_band = pmx_ribbon(fill = "grey80", alpha = 0.3, color = NA)
+    point       = pmx_point(shape = 16, size = 2.5, alpha = 1, color = "black"),
+    errorbar    = pmx_errorbar(linewidth = 0.7, linetype = 1, alpha = 1, color = "black"),
+    ref_line    = pmx_line(linewidth = 0.5, linetype = 2, alpha = 1, color = "grey40"),
+    ref_band    = pmx_ribbon(fill = "grey80", alpha = 0.3, color = NA),
+    panel_color = pmx_color()
   )
   user <- compact(list(point = point, errorbar = errorbar,
-                       ref_line = ref_line, ref_band = ref_band))
+                       ref_line = ref_line, ref_band = ref_band,
+                       panel_color = panel_color))
   pmx_theme(merge_theme(user, defaults), subclass = "plot_forest_theme")
 }
 

--- a/R/theme_internals.R
+++ b/R/theme_internals.R
@@ -26,7 +26,14 @@ compact <- function(x) x[!vapply(x, is.null, logical(1))]
 #'
 merge_element <- function(user, default) {
   if (is.null(user)) return(default)
+  if (is.null(default)) return(user)
   cls <- class(default)[1]
+  if (cls == "pmx_color") {
+    out <- default
+    for (nm in names(user)) out[[nm]] <- user[[nm]]
+    class(out) <- class(default)
+    return(out)
+  }
   valid <- element_fields(cls)
   if (length(valid) == 0) valid <- names(default)
   out <- default
@@ -51,7 +58,6 @@ element_fields <- function(cls) {
     pmx_errorbar = c("linewidth", "linetype", "alpha", "color", "width"),
     pmx_trend    = c("linewidth", "linetype", "color", "se_color", "se_alpha"),
     pmx_style    = c("color", "alpha"),
-    pmx_color    = c("dv", "pred", "ipred"),
     character(0)
   )
 }

--- a/man/plot_forest_theme.Rd
+++ b/man/plot_forest_theme.Rd
@@ -8,7 +8,8 @@ plot_forest_theme(
   point = NULL,
   errorbar = NULL,
   ref_line = NULL,
-  ref_band = NULL
+  ref_band = NULL,
+  panel_color = NULL
 )
 }
 \arguments{
@@ -20,6 +21,14 @@ plot_forest_theme(
 \item{ref_line}{Vertical no-effect reference line aesthetics. See \code{\link[=pmx_line]{pmx_line()}}.}
 
 \item{ref_band}{Shaded equivalence-interval ribbon aesthetics. See \code{\link[=pmx_ribbon]{pmx_ribbon()}}.}
+
+\item{panel_color}{Optional per-covariate color mapping. See \code{\link[=pmx_color]{pmx_color()}}.
+When supplied with at least one named entry, point and errorbar layers
+are colored by covariate (facet); the legend is suppressed since facet
+strips already label each covariate. Default is an empty \code{\link[=pmx_color]{pmx_color()}}
+(no per-covariate coloring), which keeps the single-color behavior from
+\code{point$color} / \code{errorbar$color}. Covariates absent from the palette
+render in grey50 and trigger a warning.}
 }
 \value{
 A named list of theme elements
@@ -32,6 +41,9 @@ Call with no arguments to view defaults. Pass element overrides to customize.
 plot_forest_theme()
 plot_forest_theme(point = pmx_point(shape = 18, size = 3))
 plot_forest_theme(ref_band = pmx_ribbon(fill = "skyblue", alpha = 0.2))
+plot_forest_theme(panel_color = pmx_color(
+  FOOD = "firebrick", WTBL = "steelblue", Reference = "grey20"
+))
 }
 \seealso{
 Other forest plot:

--- a/man/pmx_color.Rd
+++ b/man/pmx_color.Rd
@@ -2,26 +2,27 @@
 % Please edit documentation in R/pmx_element_class.R
 \name{pmx_color}
 \alias{pmx_color}
-\title{GOF overlay color aesthetics}
+\title{Discrete-level color aesthetics}
 \usage{
-pmx_color(dv = NULL, pred = NULL, ipred = NULL)
+pmx_color(...)
 }
 \arguments{
-\item{dv}{Color for DV central tendency. Default \code{"blue"}.}
-
-\item{pred}{Color for PRED central tendency. Default \code{"red"}.}
-
-\item{ipred}{Color for IPRED central tendency. Default \code{"green"}.}
+\item{...}{Named color arguments mapping level → color (e.g.,
+\code{dv = "blue"}, \code{FOOD = "red"}). All arguments must be named.}
 }
 \value{
 A \code{pmx_color} element object
 }
 \description{
-Creates a color element for \code{\link[=plot_gof_theme]{plot_gof_theme()}} controlling the manual
-color scale for DV, PRED, and IPRED overlay lines.
+Creates a color element that maps named discrete levels to colors. Used by
+\code{\link[=plot_gof_theme]{plot_gof_theme()}} for the DV/PRED/IPRED overlay scale and by
+\code{\link[=plot_forest_theme]{plot_forest_theme()}} (via \code{panel_color}) for per-covariate facet coloring.
+Accepts any named arguments — each name becomes a level in the resulting
+manual color scale.
 }
 \examples{
 pmx_color(dv = "black", pred = "purple", ipred = "darkgreen")
+pmx_color(FOOD = "firebrick", WTBL = "steelblue", Reference = "grey20")
 }
 \seealso{
 Other element constructors:

--- a/tests/testthat/test-element_constructors.R
+++ b/tests/testthat/test-element_constructors.R
@@ -203,8 +203,14 @@ test_that("pmx_color partial override", {
   expect_null(el$ipred)
 })
 
-test_that("pmx_color rejects unknown arguments", {
-  expect_error(pmx_color(obs = "black"), regexp = "unused argument")
+test_that("pmx_color accepts arbitrary named arguments (variadic)", {
+  el <- pmx_color(obs = "black", FOOD = "red")
+  expect_equal(el$obs, "black")
+  expect_equal(el$FOOD, "red")
+})
+
+test_that("pmx_color rejects unnamed arguments", {
+  expect_error(pmx_color("black"), regexp = "must be named")
 })
 
 #####pmx_* input validation####

--- a/tests/testthat/test-plot_forest.R
+++ b/tests/testthat/test-plot_forest.R
@@ -262,10 +262,12 @@ test_that("plot_build_forest() facet_grid uses cov_name rows only (no metric fac
   expect_true(isTRUE(p$facet$params$space_free$y))
 })
 
-test_that("plot_build_forest() sets the title to the rendered metric value", {
+test_that("plot_build_forest() leaves x, y, and title labels NULL by default", {
   stats <- df_forest(data_sad_pkforest, replicate_var = "SIM")
   p <- plot_build_forest(stats, metric = "AUCRATIO")
-  expect_equal(p$labels$title, "AUCRATIO")
+  expect_null(p$labels$x)
+  expect_null(p$labels$y)
+  expect_null(p$labels$title)
 })
 
 
@@ -399,7 +401,6 @@ test_that("plot_build_forest() picks the single metric automatically when metric
   stats <- df_forest(dplyr::filter(data_sad_pkforest, metric == "AUCRATIO"),
                      replicate_var = "SIM")
   p <- plot_build_forest(stats)
-  expect_equal(p$labels$title, "AUCRATIO")
   expect_true(all(as.character(p$data$metric) == "AUCRATIO"))
 })
 
@@ -407,7 +408,6 @@ test_that("plot_build_forest() filters stats to the named metric", {
   stats <- df_forest(data_sad_pkforest, replicate_var = "SIM")
   p <- plot_build_forest(stats, metric = "CMAXRATIO")
   expect_true(all(as.character(p$data$metric) == "CMAXRATIO"))
-  expect_equal(p$labels$title, "CMAXRATIO")
 })
 
 test_that("plot_build_forest() aborts when metric is not in stats", {

--- a/tests/testthat/test-plot_forest.R
+++ b/tests/testthat/test-plot_forest.R
@@ -213,6 +213,22 @@ test_that("plot_forest_theme() honors user element overrides", {
   expect_equal(th$point$size,  4)
 })
 
+test_that("plot_forest_theme() default panel_color is an empty pmx_color (opt-out)", {
+  th <- plot_forest_theme()
+  expect_s3_class(th$panel_color, "pmx_color")
+  expect_length(th$panel_color, 0L)
+})
+
+test_that("plot_forest_theme(panel_color = pmx_color(...)) stores the palette", {
+  th <- plot_forest_theme(panel_color = pmx_color(
+    FOOD = "firebrick", WTBL = "steelblue", Reference = "grey20"
+  ))
+  expect_s3_class(th$panel_color, "pmx_color")
+  expect_equal(th$panel_color$FOOD, "firebrick")
+  expect_equal(th$panel_color$WTBL, "steelblue")
+  expect_equal(th$panel_color$Reference, "grey20")
+})
+
 
 #####plot_build_forest -- output class#####
 
@@ -417,6 +433,46 @@ test_that("plot_forest_theme() default sizes are bumped (point 2.5, errorbar 0.7
   th <- plot_forest_theme()
   expect_equal(th$point$size, 2.5)
   expect_equal(th$errorbar$linewidth, 0.7)
+})
+
+
+#####plot_build_forest -- panel_color (per-covariate coloring)#####
+
+test_that("plot_build_forest() adds no colour scale when panel_color is empty (default)", {
+  stats <- df_forest(data_sad_pkforest, replicate_var = "SIM")
+  p <- plot_build_forest(stats, metric = "AUCRATIO")
+  scale_aes <- vapply(p$scales$scales, function(s) s$aesthetics[1], character(1))
+  expect_false("colour" %in% scale_aes)
+  expect_null(p$guides$guides$colour)
+})
+
+test_that("plot_build_forest() adds scale_color_manual when panel_color is non-empty", {
+  stats <- df_forest(data_sad_pkforest, replicate_var = "SIM")
+  p <- plot_build_forest(
+    stats, metric = "AUCRATIO",
+    theme = plot_forest_theme(panel_color = pmx_color(
+      Reference = "grey20", FOOD = "firebrick", WTBL = "steelblue"
+    ))
+  )
+  scale_aes <- vapply(p$scales$scales, function(s) s$aesthetics[1], character(1))
+  expect_true("colour" %in% scale_aes)
+  color_scale <- p$scales$scales[[which(scale_aes == "colour")]]
+  expect_equal(
+    color_scale$palette(3),
+    c(Reference = "grey20", FOOD = "firebrick", WTBL = "steelblue")
+  )
+  expect_equal(p$guides$guides$colour, "none")
+})
+
+test_that("plot_build_forest() warns when panel_color is missing entries for present covariates", {
+  stats <- df_forest(data_sad_pkforest, replicate_var = "SIM")
+  expect_warning(
+    plot_build_forest(
+      stats, metric = "AUCRATIO",
+      theme = plot_forest_theme(panel_color = pmx_color(FOOD = "red"))
+    ),
+    regexp = "panel_color.*missing entries"
+  )
 })
 
 

--- a/tests/testthat/test-pmx_element_class.R
+++ b/tests/testthat/test-pmx_element_class.R
@@ -32,6 +32,32 @@ test_that("per-type classes are mutually exclusive across element types", {
 })
 
 
+##### pmx_color() variadic #####
+
+test_that("pmx_color() accepts arbitrary named entries", {
+  pc <- pmx_color(FOOD = "firebrick", WTBL = "steelblue", Reference = "grey20")
+  expect_s3_class(pc, "pmx_color")
+  expect_equal(pc$FOOD, "firebrick")
+  expect_equal(pc$WTBL, "steelblue")
+  expect_equal(pc$Reference, "grey20")
+})
+
+test_that("pmx_color() preserves the legacy dv/pred/ipred form", {
+  pc <- pmx_color(dv = "blue", pred = "red", ipred = "green")
+  expect_equal(pc$dv, "blue")
+  expect_equal(pc$pred, "red")
+  expect_equal(pc$ipred, "green")
+})
+
+test_that("pmx_color() rejects unnamed arguments", {
+  expect_error(pmx_color("red", "blue"), regexp = "must be named")
+})
+
+test_that("pmx_color() validates color strings", {
+  expect_error(pmx_color(FOOD = "not_a_color"))
+})
+
+
 ##### print.pmx_element #####
 
 test_that("print.pmx_element() writes a banner and the set fields", {

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -104,6 +104,14 @@ data_gof <- data_sad_pkfit %>%
   mutate(Regimen = fct_relevel(Regimen, "50 mg x1 Fasted (n=6)", after = 1))
 ```
 
+## `data_sad_pkforest`
+
+`data_sad_pkforest` is a per replicate simulation dataset of PK exposure metrics (absolute and test/reference ratios) across four covariate scenarios (reference, fed, low body weight, high body weight). The per-row `cov_ref` column is already populated so that `df_forest()` will auto-disperse the reference into each covariate panel.
+
+```{r data-pkforest}
+glimpse(data_sad_pkforest)
+```
+
 
 # Longitudinal concentration and response with `plot_dvtime()`
 
@@ -220,6 +228,34 @@ plot_gof(data = filter(data_gof, MDV == 0), dv_var = ODV, log_y = TRUE) +
 ```
 
 See the [Goodness-of-Fit Diagnostics](gof-diagnostics.html) article for specifying central tendency, BLQ handling, and theme customization.
+
+# Forest plots of covariate impact with `df_forest()` and `plot_forest()`
+
+`df_forest()` aggregates values across simulation or bootstrap replicates into a point estimate and confidence interval for each covariate level, returning a class-tagged `forest_stats` object (a `pmx_stats` subclass that parallels `doseprop_stats` and `vpc_stats`).
+
+```{r forest-stats}
+forest_stats <- df_forest(data_sad_pkforest, replicate_var = "SIM")
+forest_stats
+```
+
+`plot_forest()` is dual-mode: it can take the raw replicate data (one-stage, calling `df_forest()` internally) or a precomputed `forest_stats` object (two-stage). The two-stage workflow below renders one metric at a time and composes with `ggplot2` for axis customization.
+
+```{r plot-forest-default, fig.width=8, fig.height=4, warning=FALSE, message=FALSE}
+plot_forest(forest_stats, metric = "AUCRATIO", ref_band = c(0.8, 1.25)) +
+  scale_x_log10(limits = c(0.5, 5))
+```
+
+Per-covariate panel colors can be applied via `plot_forest_theme(panel_color = pmx_color(...))`, where `pmx_color()` maps each covariate name (matching the `cov_var` column) to a color. Covariate names omitted from the mapping retain the default point/errorbar color.
+
+```{r plot-forest-themed, fig.width=8, fig.height=4, warning=FALSE, message=FALSE}
+new_forest_theme <- plot_forest_theme(
+  panel_color = pmx_color(FOOD = "darkgreen", WTBL = "darkblue")
+)
+
+plot_forest(forest_stats, metric = "AUCRATIO",
+            ref_band = c(0.8, 1.25), theme = new_forest_theme) +
+  scale_x_log10(limits = c(0.5, 5))
+```
 
 # VPC model evaluation with `plot_vpc_cont()` and `plot_vpc_cens()`
 


### PR DESCRIPTION
Add color handling per covariate facet to plot_forest() by refactoring and generalizing pmx_color constructor for use in both plot_gof_theme() and plot_forest_theme()